### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
-This repository contains an event-driven simulator for elastic optical networks to study the problem of routing, modulation, and spectrum allocation (RMSA), as well as quality of service metrics. In the event that the simulator is utilized in an academic context, proper citation is required.
+This repository contains an event-driven simulator for elastic optical networks to study the problem of Routing, Modulation, Core, and Spectrum Allocation (RMCSA), as well as quality of service metrics. In the event that the simulator is utilized in an academic context, proper citation is required.
 
 > More detailed documentation is currently being written. Please wait. Consider visiting the [official page](https://assodepicche.github.io/elastic-optical-networks/) for this application.
+
 ## Scope and Features
 
 The scope of this project consists of analyzing network behavior in different configuration contexts, such as topology, traffic, routing policies, and resource allocation. Multiple topologies are available by default, however, it is possible to use any desired topology, as long as it follows the application standards.
@@ -30,7 +31,7 @@ If you use this application in your research, please cite:
 First install and configure all necessary dependencies, then clone this repository:
 
 ```bash
-git clone git@github.com:AssoDePicche/elastic-optical-networks.git --recursive
+git clone git@github.com:AssoDePicche/elastic-optical-networks.git
 ```
 
 After that, use the available scripts to perform the build, tests, and profiling.
@@ -44,7 +45,7 @@ After that, use the available scripts to perform the build, tests, and profiling
 Once the application has been built, you can run it. To modify the simulation parameters, edit the [settings.json](resources/configuration/settings.json) file.
 
 ```bash
-./build/App
+./App-linux-x86_64
 ```
 
 When the simulation ends, it saves a .csv file with the simulation data and a report.txt file is created with the results.

--- a/application/core/allocation.h
+++ b/application/core/allocation.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <cstdint>
+
+#include "flexgrid.h"
+
+namespace core {
+struct Slice final {
+  uint16_t firstFSU;
+  uint16_t lastFSU;
+};
+
+struct Allocation final {
+  Slice slice;
+  uint16_t link;
+  uint8_t core;
+};
+};

--- a/application/core/flexgrid.cpp
+++ b/application/core/flexgrid.cpp
@@ -3,7 +3,7 @@
 #include <cassert>
 
 namespace core {
-struct FSU final {
+struct FrequencySlotUnit final {
   uint16_t timesAllocated{0};
   bool isAllocated{false};
 
@@ -29,7 +29,7 @@ struct Flexgrid::Implementation final {
     const size_t totalSize =
         static_cast<size_t>(fsusPerCore * coresPerFiber * links);
 
-    buffer = std::make_unique<FSU[]>(totalSize);
+    buffer = std::make_unique<FrequencySlotUnit[]>(totalSize);
   }
 
   void Allocate(const Lightpath& lightpath) {
@@ -63,7 +63,7 @@ struct Flexgrid::Implementation final {
   }
 
  private:
-  std::unique_ptr<FSU[]> buffer;
+  std::unique_ptr<FrequencySlotUnit[]> buffer;
   uint16_t fsusPerCore;
   uint8_t coresPerFiber;
   uint16_t links;
@@ -81,9 +81,9 @@ struct Flexgrid::Implementation final {
            static_cast<size_t>(link) * fsusPerCore * coresPerFiber;
   }
 
-  FSU& GetFSU(const Unit unit) { return buffer[Index3D(unit)]; }
+  FrequencySlotUnit& GetFSU(const Unit unit) { return buffer[Index3D(unit)]; }
 
-  const FSU& GetFSU(const Unit unit) const { return buffer[Index3D(unit)]; }
+  const FrequencySlotUnit& GetFSU(const Unit unit) const { return buffer[Index3D(unit)]; }
 };
 
 Flexgrid::Flexgrid(const uint16_t fsusPerCore, const uint8_t coresPerFiber,

--- a/application/core/flexgrid.cpp
+++ b/application/core/flexgrid.cpp
@@ -83,7 +83,9 @@ struct Flexgrid::Implementation final {
 
   FrequencySlotUnit& GetFSU(const Unit unit) { return buffer[Index3D(unit)]; }
 
-  const FrequencySlotUnit& GetFSU(const Unit unit) const { return buffer[Index3D(unit)]; }
+  const FrequencySlotUnit& GetFSU(const Unit unit) const {
+    return buffer[Index3D(unit)];
+  }
 };
 
 Flexgrid::Flexgrid(const uint16_t fsusPerCore, const uint8_t coresPerFiber,

--- a/application/core/flexgrid.cpp
+++ b/application/core/flexgrid.cpp
@@ -32,27 +32,7 @@ struct Flexgrid::Implementation final {
     buffer = std::make_unique<FrequencySlotUnit[]>(totalSize);
   }
 
-  void Allocate(const Lightpath& lightpath) {
-    for (const auto& allocation : lightpath) {
-      for (auto fsu = allocation.slice.firstFSU;
-           fsu <= allocation.slice.lastFSU; ++fsu) {
-        GetFSU({.fsu = fsu, .link = allocation.link, .core = allocation.core})
-            .Allocate();
-      }
-    }
-  }
-
   void Allocate(const Unit unit) { GetFSU(unit).Allocate(); }
-
-  void Deallocate(const Lightpath& lightpath) {
-    for (const auto& allocation : lightpath) {
-      for (auto fsu = allocation.slice.firstFSU;
-           fsu <= allocation.slice.lastFSU; ++fsu) {
-        GetFSU({.fsu = fsu, .link = allocation.link, .core = allocation.core})
-            .Deallocate();
-      }
-    }
-  }
 
   void Deallocate(const Unit unit) { GetFSU(unit).Deallocate(); }
 
@@ -99,15 +79,7 @@ Flexgrid::Flexgrid(Flexgrid&&) noexcept = default;
 
 Flexgrid& Flexgrid::operator=(Flexgrid&&) noexcept = default;
 
-void Flexgrid::Allocate(const Lightpath& lightpath) {
-  pImpl->Allocate(lightpath);
-}
-
 void Flexgrid::Allocate(const Unit unit) { pImpl->Allocate(unit); }
-
-void Flexgrid::Deallocate(const Lightpath& lightpath) {
-  pImpl->Deallocate(lightpath);
-}
 
 void Flexgrid::Deallocate(const Unit unit) { pImpl->Deallocate(unit); }
 

--- a/application/core/flexgrid.h
+++ b/application/core/flexgrid.h
@@ -3,8 +3,6 @@
 #include <cstdint>
 #include <memory>
 
-#include "lightpath.h"
-
 namespace core {
 class Flexgrid final {
  public:
@@ -26,11 +24,7 @@ class Flexgrid final {
 
   Flexgrid& operator=(Flexgrid&&) noexcept;
 
-  void Allocate(const Lightpath&);
-
   void Allocate(const Unit);
-
-  void Deallocate(const Lightpath&);
 
   void Deallocate(const Unit);
 

--- a/application/core/lightpath.h
+++ b/application/core/lightpath.h
@@ -1,19 +1,9 @@
 #pragma once
 
-#include <cstdint>
+#include "allocation.h"
+
 #include <vector>
 
 namespace core {
-struct Slice final {
-  uint16_t firstFSU;
-  uint16_t lastFSU;
-};
-
-struct Allocation final {
-  Slice slice;
-  uint16_t link;
-  uint8_t core;
-};
-
 using Lightpath = std::vector<Allocation>;
 }  // namespace core

--- a/application/test/CMakeLists.txt
+++ b/application/test/CMakeLists.txt
@@ -1,4 +1,5 @@
 add_executable(Tests
+  flexgrid.cpp
   main.cpp
   spectrum.cpp
 )

--- a/application/test/flexgrid.cpp
+++ b/application/test/flexgrid.cpp
@@ -1,0 +1,32 @@
+#include <cstdint>
+
+#include <gtest/gtest.h>
+
+#include <core/flexgrid.h>
+
+TEST(Flexgrid, Allocation) {
+  const uint16_t fsusPerCore = 5;
+
+  const uint8_t coresPerFiber = 1;
+
+  const uint16_t links = 2;
+
+  core::Flexgrid flexgrid(fsusPerCore, coresPerFiber, links);
+
+  const core::Flexgrid::Unit unit = {
+    .fsu = 0,
+    .link = 0,
+    .core = 0,
+  };
+
+  ASSERT_EQ(flexgrid.IsAllocated(unit), false);
+
+  flexgrid.Allocate(unit);
+
+  ASSERT_EQ(flexgrid.IsAllocated(unit), true);
+
+  flexgrid.Deallocate(unit);
+
+  ASSERT_EQ(flexgrid.IsAllocated(unit), false);
+
+}

--- a/application/test/flexgrid.cpp
+++ b/application/test/flexgrid.cpp
@@ -1,8 +1,8 @@
-#include <cstdint>
-
+#include <core/flexgrid.h>
 #include <gtest/gtest.h>
 
-#include <core/flexgrid.h>
+#include <cstdint>
+#include <vector>
 
 TEST(Flexgrid, Allocation) {
   const uint16_t fsusPerCore = 5;
@@ -13,20 +13,30 @@ TEST(Flexgrid, Allocation) {
 
   core::Flexgrid flexgrid(fsusPerCore, coresPerFiber, links);
 
-  const core::Flexgrid::Unit unit = {
-    .fsu = 0,
-    .link = 0,
-    .core = 0,
+  std::vector<core::Flexgrid::Unit> units = {
+      {
+          .fsu = 0,
+          .link = 0,
+          .core = 0,
+
+      },
+      {
+          .fsu = 1,
+          .link = 0,
+          .core = 0,
+
+      },
   };
 
-  ASSERT_EQ(flexgrid.IsAllocated(unit), false);
+  for (const auto& unit : units) {
+    ASSERT_FALSE(flexgrid.IsAllocated(unit));
 
-  flexgrid.Allocate(unit);
+    flexgrid.Allocate(unit);
 
-  ASSERT_EQ(flexgrid.IsAllocated(unit), true);
+    ASSERT_TRUE(flexgrid.IsAllocated(unit));
 
-  flexgrid.Deallocate(unit);
+    flexgrid.Deallocate(unit);
 
-  ASSERT_EQ(flexgrid.IsAllocated(unit), false);
-
+    ASSERT_FALSE(flexgrid.IsAllocated(unit));
+  }
 }


### PR DESCRIPTION
# Flexgrid, Allocation and Lightpath

## Changes

### README
* Add Core assignment to README and update application execution example

### Core
* core/flexgrid.cpp: rename FSU struct to FrequencySlotUnit and remove Lightpath allocation member functions
* core/lightpath.h: move Slice and Lightpath definitions to its own header

### Test
* test/flexgrid.cpp: add flexgrid allocation test